### PR TITLE
Add option to clean before run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Next, optionally, specify the options in your `config/stage/deploy.rb` file, how
     set :docker_copy_data - docker does not allow us to use symlinks so this is just a substitute for linked_files (and linked_dirs), however instead of linking it simply copy the contents, so these will be visible inside image
     set :docker_cpu_quota - specify the value for --cpu-quota option when running containers (does not work with docker-compose)
     set :docker_apparmor_profile - run docker containers with specified apparmor profile
-
+    set :docker_clean_before_run - stops and removes existing containers before running a new one (useful when running containers with -p option), defaults to false
+    
 
     set :docker_compose - should we use docker-compose strategy instead (note - all above options are obsolete using this option), using docker-compose requires you to have docker-compose.yml file in your root directory, defaults to false
     set :docker_compose_project_name - prefix for the container names, defaults to nil, so it defaults to the directory name the project is at
@@ -66,6 +67,7 @@ Next, optionally, specify the options in your `config/stage/deploy.rb` file, how
     set :docker_pass_env - the list of the environment variables that should be passed over to the docker-compose commands from command line (they are validated wether they exists before they are used) (ex: PULL_REQUEST_ID=10 cap staging docker:compose:start )
     set :docker_assets_precompile_command - command to be executed as assets precompile task (when capistrano/docker/assets is used, defaults to 'rake assets:precompile')
     set :docker_migrate_command - command to be executed as migration task (when capistrano/docker/migration is used, defaults to 'rake db:migrate')
+    set :docker_db_create_command - command to be executed as database creation task (use for first run deployments, defaults to 'rake db:create')
     set :docker_npm_install_command - command to be executed for installing npm packages, defaults to 'npm install --production --no-spin'
     set :docker_bower_install_command - command to be executed for intalling bower packages, defaults to 'bower install --production'
 

--- a/capistrano-docker.gemspec
+++ b/capistrano-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-docker'
-  spec.version       = '0.2.8'
+  spec.version       = '0.2.9'
   spec.authors       = ["Jacek Jakubik"]
   spec.email         = ["jacek.jakubik@netguru.pl"]
   spec.description   = %q{Docker support for Capistrano 3.x}

--- a/capistrano-docker.gemspec
+++ b/capistrano-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-docker'
-  spec.version       = '0.2.9'
+  spec.version       = '0.2.10'
   spec.authors       = ["Jacek Jakubik"]
   spec.email         = ["jacek.jakubik@netguru.pl"]
   spec.description   = %q{Docker support for Capistrano 3.x}

--- a/capistrano-docker.gemspec
+++ b/capistrano-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-docker'
-  spec.version       = '0.2.10'
+  spec.version       = '0.2.9'
   spec.authors       = ["Jacek Jakubik"]
   spec.email         = ["jacek.jakubik@netguru.pl"]
   spec.description   = %q{Docker support for Capistrano 3.x}

--- a/capistrano-docker.gemspec
+++ b/capistrano-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-docker'
-  spec.version       = '0.2.10'
+  spec.version       = '0.2.11'
   spec.authors       = ["Jacek Jakubik"]
   spec.email         = ["jacek.jakubik@netguru.pl"]
   spec.description   = %q{Docker support for Capistrano 3.x}

--- a/capistrano-docker.gemspec
+++ b/capistrano-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-docker'
-  spec.version       = '0.2.11'
+  spec.version       = '0.2.12'
   spec.authors       = ["Jacek Jakubik"]
   spec.email         = ["jacek.jakubik@netguru.pl"]
   spec.description   = %q{Docker support for Capistrano 3.x}

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -78,6 +78,7 @@ namespace :load do
     set :docker_copy_data,            -> { [] }
     set :docker_pass_env,             -> { [] }
     set :docker_cpu_quota,            -> { nil }
+    set :docker_clean_before_run,      -> { false }
 
     set :docker_compose,                    -> { false }
     set :docker_compose_project_name,       -> { nil }

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -35,7 +35,10 @@ namespace :docker do
 
   def task_command(command)
     cmd = ["run"]
-
+    
+    # clean up temp volumes
+    cmd << "--rm"
+    
     # attach volumes
     fetch(:docker_volumes).each do |volume|
       cmd << "-v #{volume}"

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -91,6 +91,7 @@ namespace :load do
 
     # migration
     set :docker_migrate_command,           -> { "rake db:migrate" }
+    set :docker_db_create_command,         -> { "rake db:create" }
 
     # npm
     set :docker_npm_install_command,       -> { "npm install --production --no-spin"}

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -70,8 +70,9 @@ namespace :docker do
   end
 
   def old_containers
-    cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}' | grep "#{fetch(:docker_image)}")
-    capture(cmd).split("\n").map { |x| x.split(" ") }
+    cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}')
+    resp = capture(cmd).split("\n").map { |x| x.split(" ") }
+    resp.select { |a| a[1].index('#{fetch(:docker_image)}')}
   end
 
   def remove_container(container)

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -71,7 +71,8 @@ namespace :docker do
 
   def old_containers
     cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}' | grep "#{fetch(:docker_image)}")
-    capture(cmd).split("\n").map { |x| x.split(" ") }
+    found = capture(cmd)
+    found.split("\n").map { |x| x.split(" ") } if (found)
   end
 
   def remove_container(container)

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -71,8 +71,7 @@ namespace :docker do
 
   def old_containers
     cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}' | grep "#{fetch(:docker_image)}")
-    found = capture(cmd)
-    found.split("\n").map { |x| x.split(" ") } if (found)
+    capture(cmd).split("\n").map { |x| x.split(" ") }
   end
 
   def remove_container(container)

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -1,7 +1,9 @@
 namespace :docker do
   namespace :deploy do
     task :default do
-      %w( prepare build run clean tag ).each do |task|
+      order = %w( prepare build run clean tag )
+      order = %w( prepare build clean run tag ) if fetch(:docker_clean_before_run)
+      order.each do |task|
         invoke "docker:deploy:default:#{task}"
       end
     end

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -71,8 +71,7 @@ namespace :docker do
 
   def old_containers
     cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}' | grep "#{fetch(:docker_image)}")
-    resp = capture(cmd), raise_on_non_zero_exit: false
-    resp.split("\n").map { |x| x.split(" ") }
+    capture(cmd).split("\n").map { |x| x.split(" ") }
   end
 
   def remove_container(container)

--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -71,7 +71,8 @@ namespace :docker do
 
   def old_containers
     cmd = %(docker ps -f "name=#{fetch(:application)}_" --format '{{.ID}} {{.Image}} {{.Label "git.revision.id"}}' | grep "#{fetch(:docker_image)}")
-    capture(cmd).split("\n").map { |x| x.split(" ") }
+    resp = capture(cmd), raise_on_non_zero_exit: false
+    resp.split("\n").map { |x| x.split(" ") }
   end
 
   def remove_container(container)

--- a/lib/capistrano/tasks/docker/migration.rake
+++ b/lib/capistrano/tasks/docker/migration.rake
@@ -1,5 +1,11 @@
 namespace :docker do
   namespace :migration do
+    task :create do
+      on roles(fetch(:docker_role)) do
+        execute :docker, task_command(fetch(:docker_db_create_command))
+      end
+    end
+    
     task :migrate do
       on roles(fetch(:docker_role)) do
         execute :docker, task_command(fetch(:docker_migrate_command))


### PR DESCRIPTION
- Containers started with an option such as -p 80:9292 need to be
  stopped before subsequent containers are started with the same
  option, otherwise there will be a conflict. Added an option
  "docker_clean_before_run" which defaults to false in order to
  preserve original behaviour. When set to true, tasks will be
  executed as "prepare build clean run tag" instead of
  "prepare build run clean tag".

It might be more correct to simply stop the previous container as part of the 'run' task and then allowing the normal clean to go ahead, rather than cleaning by changing the order of tasks as I have done here. However that would also involve changing the existing 'old_containers' method to use 'ps -a' in order to find the already stopped containers. That may in fact be a desirable change though as it would clean and remove old containers that have stopped for other reasons than a deployment.
