### PR TITLE
Remove -f flag from docker tag command

### DIFF
--- a/lib/capistrano/tasks/docker/default.rake
+++ b/lib/capistrano/tasks/docker/default.rake
@@ -58,7 +58,7 @@ namespace :docker do
 
       task :tag do
         on roles(fetch(:docker_role)) do
-          execute :docker, "tag -f #{fetch(:docker_image_full)} #{fetch(:docker_image)}:latest"
+          execute :docker, "tag #{fetch(:docker_image_full)} #{fetch(:docker_image)}:latest"
         end
       end
     end


### PR DESCRIPTION
## Decription

-f flag was removed from docker tag command in docker 1.10.0 - you can read more here: https://github.com/docker/docker/blob/master/CHANGELOG.md#deprecations
